### PR TITLE
chore(deps): bump https://github.com/craft-de-jet/dashboard-api-springboot.git 

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,3 +3,4 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [craft-de-jet/dashboard-ui](https://github.com/craft-de-jet/dashboard-ui.git) |  | []() | 
+[craft-de-jet/dashboard-api-springboot](https://github.com/craft-de-jet/dashboard-api-springboot.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -5,3 +5,9 @@ dependencies:
   url: https://github.com/craft-de-jet/dashboard-ui.git
   version: ""
   versionURL: ""
+- host: github.com
+  owner: craft-de-jet
+  repo: dashboard-api-springboot
+  url: https://github.com/craft-de-jet/dashboard-api-springboot.git
+  version: ""
+  versionURL: ""

--- a/repositories/templates/craft-de-jet-dashboard-api-springboot-sr.yaml
+++ b/repositories/templates/craft-de-jet-dashboard-api-springboot-sr.yaml
@@ -1,6 +1,8 @@
 apiVersion: jenkins.io/v1
 kind: SourceRepository
 metadata:
+  annotations:
+    jenkins.io/last-build-number-for-master: "1"
   creationTimestamp: null
   labels:
     owner: craft-de-jet

--- a/repositories/templates/craft-de-jet-dashboard-api-springboot-sr.yaml
+++ b/repositories/templates/craft-de-jet-dashboard-api-springboot-sr.yaml
@@ -2,7 +2,7 @@ apiVersion: jenkins.io/v1
 kind: SourceRepository
 metadata:
   annotations:
-    jenkins.io/last-build-number-for-master: "1"
+    jenkins.io/last-build-number-for-master: "2"
   creationTimestamp: null
   labels:
     owner: craft-de-jet
@@ -20,4 +20,4 @@ spec:
   scheduler:
     kind: ""
     name: ""
-  url: git@github.com:craft-de-jet/dashboard-api-springboot.git
+  url: https://github.com/craft-de-jet/dashboard-api-springboot.git

--- a/repositories/templates/craft-de-jet-dashboard-api-springboot-sr.yaml
+++ b/repositories/templates/craft-de-jet-dashboard-api-springboot-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: craft-de-jet
+    provider: github
+    repository: dashboard-api-springboot
+  name: craft-de-jet-dashboard-api-springboot
+spec:
+  description: Imported application for craft-de-jet/dashboard-api-springboot
+  httpCloneURL: https://github.com/craft-de-jet/dashboard-api-springboot.git
+  org: craft-de-jet
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: dashboard-api-springboot
+  scheduler:
+    kind: ""
+    name: ""
+  url: git@github.com:craft-de-jet/dashboard-api-springboot.git


### PR DESCRIPTION
Update [craft-de-jet/dashboard-api-springboot](https://github.com/craft-de-jet/dashboard-api-springboot.git) 

Command run was `jx create quickstart -f spring`
<hr />

Update [craft-de-jet/dashboard-api-springboot](https://github.com/craft-de-jet/dashboard-api-springboot.git) 

Command run was `jx import`
<hr />

Update [craft-de-jet/dashboard-api-springboot](https://github.com/craft-de-jet/dashboard-api-springboot.git) 

Command run was `jx import`